### PR TITLE
One request to rule them all, one request to find them, one request to bring them all

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -50,63 +50,63 @@ var API = {
 };
 
 
-    // Populates the interactive map with states that have Unlimited data providers
-    $.ajax({
-        url: API.url + 'fame/',
-        type: 'GET',
-        dataType: 'json',
-    })
-    .done(function(data) {
+// Populates the interactive map with states that have Unlimited data providers
+$.ajax({
+    url: API.url + 'fame/',
+    type: 'GET',
+    dataType: 'json',
+})
+.done(function(data) {
 
-        var providers = data.providers;
-        var estados = [];
+    var providers = data.providers;
+    var estados = [];
 
-        // Get the states that each provider covers and add it to an array
-        for(var i = 0; i < providers.length; i++) {
-            var provider = providers[i];
-            estados = estados.concat(provider.coverage);
+    // Get the states that each provider covers and add it to an array
+    for(var i = 0; i < providers.length; i++) {
+        var provider = providers[i];
+        estados = estados.concat(provider.coverage);
+    }
+
+    // Remove duplicate entries from the array and add the hasProvider class to the related SVG markup in the page
+    estados = getUnique(estados);
+    $(document).ready(function($) {
+        for (var i = 0; i <  estados.length; i++) {
+            $('#' + estados[i]).addClass('hasProvider');
         }
-
-        // Remove duplicate entries from the array and add the hasProvider class to the related SVG markup in the page
-        estados = getUnique(estados);
-        $(document).ready(function($) {
-            for (var i = 0; i <  estados.length; i++) {
-                $('#' + estados[i]).addClass('hasProvider');
-            }
-        });
-    })
-    .fail(function(err) {
-        console.log('error: ', err);
     });
+})
+.fail(function(err) {
+    console.log('error: ', err);
+});
 
-    // Populates the hall of shame on page load.
-    $.ajax({
-        url: API.url + 'shame/',
-        type: 'GET',
-        dataType: 'json',
-    })
-    .done(function(data) {
+// Populates the hall of shame on page load.
+$.ajax({
+    url: API.url + 'shame/',
+    type: 'GET',
+    dataType: 'json',
+})
+.done(function(data) {
 
-        // Creates an array with jQuery objects that will be appended to the markup down below
-        var providers = data.providers;
-        var list = [];
-        for(var i = 0; i < data.providers.length; i++) {
-            list.push(
-                $('<div />', {'class': 'column text-center'}).append(
-                    $('<h3 />').text(providers[i].name),
-                    $('<p />').append(
-                        $('<a />', {'href': providers[i].source}).text('Fonte')
-                    )
+    // Creates an array with jQuery objects that will be appended to the markup down below
+    var providers = data.providers;
+    var list = [];
+    for(var i = 0; i < data.providers.length; i++) {
+        list.push(
+            $('<div />', {'class': 'column text-center'}).append(
+                $('<h3 />').text(providers[i].name),
+                $('<p />').append(
+                    $('<a />', {'href': providers[i].source}).text('Fonte')
                 )
-            );
-        }
-        $(document).ready(function($) {
-            $('.isp--hell').append(list);
-        });
-    })
-    .fail(function(err) {
-        console.log("error: ", err);
+            )
+        );
+    }
+    $(document).ready(function($) {
+        $('.isp--hell').append(list);
     });
+})
+.fail(function(err) {
+    console.log("error: ", err);
+});
 
 /**
  * On click of every state in the interactive map we will make an API call to fetch all the providers

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,111 +1,92 @@
 $(document).foundation();
 
-// Little helper function to remove duplicate values of an array
-function getUnique(arr) {
-   var u = {}, a = [];
-   for(var i = 0, l = arr.length; i < l; ++i){
-      if(u.hasOwnProperty(arr[i])) {
-         continue;
-      }
-      a.push(arr[i]);
-      u[arr[i]] = 1;
-   }
-   return a;
-}
-
 // Anything related to the API that can/will be reused should be placed in there
 var API = {
     // Default API url
     'url': 'https://internetsemlimites.herokuapp.com/api/',
     // Maps acronym to State names for pretty printing
     'statesMap': {
-        'AC': 'Acre',
-        'AL': 'Alagoas',
-        'AM': 'Amazonas',
-        'AP': 'Amapá',
-        'BA': 'Bahia',
-        'CE': 'Ceará',
-        'DF': 'Distrito Federal',
-        'ES': 'Espírito Santo',
-        'GO': 'Goiás',
-        'MA': 'Maranhão',
-        'MG': 'Minas Gerais',
-        'MS': 'Mato Grosso do Sul',
-        'MT': 'Mato Grosso',
-        'PA': 'Pará',
-        'PB': 'Paraíba',
-        'PE': 'Pernambuco',
-        'PI': 'Piauí',
-        'PR': 'Paraná',
-        'RJ': 'Rio de Janeiro',
-        'RN': 'Rio Grande do Norte',
-        'RO': 'Rondônia',
-        'RR': 'Roraima',
-        'RS': 'Rio Grande do Sul',
-        'SC': 'Santa Catarina',
-        'SE': 'Sergipe',
-        'SP': 'São Paulo',
-        'TO': 'Tocantins'
-    }
+        'AC': { name: 'Acre', providers: [] },
+        'AL': { name: 'Alagoas', providers: [] },
+        'AM': { name: 'Amazonas', providers: [] },
+        'AP': { name: 'Amapá', providers: [] },
+        'BA': { name: 'Bahia', providers: [] },
+        'CE': { name: 'Ceará', providers: [] },
+        'DF': { name: 'Distrito Federal', providers: [] },
+        'ES': { name: 'Espírito Santo', providers: [] },
+        'GO': { name: 'Goiás', providers: [] },
+        'MA': { name: 'Maranhão', providers: [] },
+        'MG': { name: 'Minas Gerais', providers: [] },
+        'MS': { name: 'Mato Grosso do Sul', providers: [] },
+        'MT': { name: 'Mato Grosso', providers: [] },
+        'PA': { name: 'Pará', providers: [] },
+        'PB': { name: 'Paraíba', providers: [] },
+        'PE': { name: 'Pernambuco', providers: [] },
+        'PI': { name: 'Piauí', providers: [] },
+        'PR': { name: 'Paraná', providers: [] },
+        'RJ': { name: 'Rio de Janeiro', providers: [] },
+        'RN': { name: 'Rio Grande do Norte', providers: [] },
+        'RO': { name: 'Rondônia', providers: [] },
+        'RR': { name: 'Roraima', providers: [] },
+        'RS': { name: 'Rio Grande do Sul', providers: [] },
+        'SC': { name: 'Santa Catarina', providers: [] },
+        'SE': { name: 'Sergipe', providers: [] },
+        'SP': { name: 'São Paulo', providers: [] },
+        'TO': { name: 'Tocantins', providers: [] },
+    },
+    'hallOfShame': []
 };
 
 
-// Populates the interactive map with states that have Unlimited data providers
+// Populates the interactive map with states that have Unlimited data providers and the Hall of Shame
 $.ajax({
-    url: API.url + 'fame/',
+    url: API.url,
     type: 'GET',
     dataType: 'json',
 })
 .done(function(data) {
 
-    var providers = data.providers;
-    var estados = [];
+    // Hall of Fame (populate map)
+    var fame = data['hall-of-fame'];
+    var states = []
 
-    // Get the states that each provider covers and add it to an array
-    for(var i = 0; i < providers.length; i++) {
-        var provider = providers[i];
-        estados = estados.concat(provider.coverage);
+    // Group the providers by state
+    for (var provider of fame) {
+        for (var state of provider.coverage) {
+
+            // add provider to the given state provider list
+            API.statesMap[state].providers.push(provider);
+
+            // build an array with unique states (to handle hasProvider CSS class later)
+            if (states.indexOf(state) === -1) {
+              states.push(state);
+            }
+
+        }
     }
 
-    // Remove duplicate entries from the array and add the hasProvider class to the related SVG markup in the page
-    estados = getUnique(estados);
+    // Add the hasProvider class to the related SVG markup in the page
     $(document).ready(function($) {
-        for (var i = 0; i <  estados.length; i++) {
-            $('#' + estados[i]).addClass('hasProvider');
-        }
+        states.map((state) => $(`#${state}`).addClass('hasProvider'));
     });
-})
-.fail(function(err) {
-    console.log('error: ', err);
-});
 
-// Populates the hall of shame on page load.
-$.ajax({
-    url: API.url + 'shame/',
-    type: 'GET',
-    dataType: 'json',
-})
-.done(function(data) {
-
-    // Creates an array with jQuery objects that will be appended to the markup down below
-    var providers = data.providers;
-    var list = [];
-    for(var i = 0; i < data.providers.length; i++) {
-        list.push(
+    // Hall of Shame (populate footer)
+    var shame = data['hall-of-shame'];
+    var listOfShamefulProviders = shame.map((provider) => {
+        return (
             $('<div />', {'class': 'column text-center'}).append(
-                $('<h3 />').text(providers[i].name),
-                $('<p />').append(
-                    $('<a />', {'href': providers[i].source}).text('Fonte')
+                $('<h3 />').text(provider.name).append(
+                    $('<a />', {'href': provider.source}).html('<svg class="svg-icon" viewBox="0 0 1000 858"><use xlink:href="#svg-icon--link"></use></svg>')
                 )
             )
         );
-    }
+    });
     $(document).ready(function($) {
-        $('.isp--hell').append(list);
+        $('.isp--hell').append(listOfShamefulProviders);
     });
 })
-.fail(function(err) {
-    console.log("error: ", err);
+.fail(function (xhr, status, err) {
+    console.error(url, status, err.toString());
 });
 
 /**
@@ -120,48 +101,37 @@ $(document).on('click', '.estados.hasProvider', function(event) {
     }
 
     var id = $(this).attr('id');
-    $.ajax({
-        url: API.url + id + '/fame/',
-        type: 'GET',
-        dataType: 'json',
-    })
-    .done(function(data) {
-        var providers = data.providers;
+    var providers = API.statesMap[id].providers;
 
-        // If for some reason the call succeds but we don't get a valid list of providers, return early.
-        if (id && providers.length > 0) {
-            $('.isp-list--content').html('');
-        } else {
-            return;
-        }
+    // If for some reason the call succeds but we don't get a valid list of providers, return early.
+    if (id && providers.length > 0) {
+        $('.isp-list--content').html('');
+    } else {
+        return;
+    }
 
-        // Call was successful, let's clear up the old selected state in the map
-        $('.estados').removeClass('active');
-        $('.isp-list--header').removeClass('hide');
+    // Call was successful, let's clear up the old selected state in the map
+    $('.estados').removeClass('active');
+    $('.isp-list--header').removeClass('hide');
 
-        // Update the title of the card to match the currently selected state.
-        $('.state-card--title').text(API.statesMap[id]);
+    // Update the title of the card to match the currently selected state.
+    $('.state-card--title').text(API.statesMap[id].name);
 
-        // Loop through each of the returned providers to create a list of jQuery objects that will
-        // be appended to the markup
-        var list = [];
-        for(var i = 0; i < providers.length; i++) {
-            list.push(
-                $('<div />', {'class': 'isp-list--isp'}).append(
-                    $('<a />', {'class': 'isp-list--left', 'href': providers[i].url}).text(providers[i].name),
-                    $('<span />', {'class': 'isp-list--right'}).append(
-                        $('<a />', {'href': providers[i].source}).html('<svg class="svg-icon" viewBox="0 0 1000 858"><use xlink:href="#svg-icon--link"></use></svg>')
-                    )
+    // Loop through each of the returned providers to create a list of jQuery objects that will
+    // be appended to the markup
+    var listOfProviders = providers.map((provider) => {
+        return (
+            $('<div />', {'class': 'isp-list--isp'}).append(
+                $('<a />', {'class': 'isp-list--left', 'href': provider.url}).text(provider.name),
+                $('<span />', {'class': 'isp-list--right'}).append(
+                    $('<a />', {'href': provider.source}).html('<svg class="svg-icon" viewBox="0 0 1000 858"><use xlink:href="#svg-icon--link"></use></svg>')
                 )
-            );
-        }
-        $('.isp-list--content').append(list);
+            )
+        );
+    });
+    $('.isp-list--content').append(listOfProviders);
 
-        // Add the .active class to the selected state since we'll now be displaying its information
-        $('#' + id).addClass('active');
-    })
-    .fail(function(err) {
-        console.log('error: ',err);
-    })
+    // Add the .active class to the selected state since we'll now be displaying its information
+    $('#' + id).addClass('active');
 
 });

--- a/src/assets/scss/layout.scss
+++ b/src/assets/scss/layout.scss
@@ -98,9 +98,13 @@ section {
     color: $white;
     a {
         color: $light-gray;
+        margin-left: 8px;
         &:hover {
             color: $medium-gray;
         }
+    }
+    .svg-icon {
+        width: 16px;
     }
 }
 


### PR DESCRIPTION
Currently the SPA reachs the API several times: one to load the _hall of fame_, one to load the _hall of shame_, plus one extra each time a state is clicked.

This _pull request_ implements some minor tweaks to:
1. load all the data the SPA needs in a single API request (starting at `assets/js/app.js`,line 42) 
2. store all the data at the `API` object (variable starting at line 4)
3. adapts the code to use the local `API` object instead of further remote API requests

Hence, just one request is needed to have a fully working SPA.
